### PR TITLE
Feat: 이메일로 사용자 조회 api 추가

### DIFF
--- a/src/main/java/example/com/moneymergebe/domain/book/dto/request/BookSaveReq.java
+++ b/src/main/java/example/com/moneymergebe/domain/book/dto/request/BookSaveReq.java
@@ -2,6 +2,7 @@ package example.com.moneymergebe.domain.book.dto.request;
 
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.Setter;
@@ -10,10 +11,13 @@ import lombok.Setter;
 @Setter
 public class BookSaveReq {
     private Long userId; // 가계부 생성한 사용자 ID
+    @NotBlank
     private String title;
 
     @Pattern(regexp = "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$", message = "유효한 HEX 코드 형식이 아닙니다.")
-    private String color;
+    private String bookColor;
+    @Pattern(regexp = "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$", message = "유효한 HEX 코드 형식이 아닙니다.")
+    private String userColor;
     private Long yearGoal;
     private Long monthGoal;
 

--- a/src/main/java/example/com/moneymergebe/domain/book/service/BookService.java
+++ b/src/main/java/example/com/moneymergebe/domain/book/service/BookService.java
@@ -61,10 +61,12 @@ public class BookService {
                 .title(req.getTitle())
                 .yearGoal(req.getYearGoal())
                 .monthGoal(req.getMonthGoal())
-                .color(req.getColor())
+                .color(req.getBookColor())
                 .build()
         );
 
+        BookUser bookUser = bookUserRepository.save(BookUser.builder().book(book).user(findUser(req.getUserId())).build());
+        bookUser.updateUserColor(req.getUserColor());
         for (Long userId : req.getUserList()) {
             User user = findUser(userId);
             bookUserRepository.save(BookUser.builder().book(book).user(user).build());

--- a/src/main/java/example/com/moneymergebe/domain/receipt/dto/response/ReceiptLikeRes.java
+++ b/src/main/java/example/com/moneymergebe/domain/receipt/dto/response/ReceiptLikeRes.java
@@ -1,8 +1,12 @@
 package example.com.moneymergebe.domain.receipt.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
 
-@JsonIgnoreProperties
+@Getter
 public class ReceiptLikeRes {
+    private int likeCount;
 
+    public ReceiptLikeRes(int likeCount) {
+        this.likeCount = likeCount;
+    }
 }

--- a/src/main/java/example/com/moneymergebe/domain/receipt/service/ReceiptService.java
+++ b/src/main/java/example/com/moneymergebe/domain/receipt/service/ReceiptService.java
@@ -92,7 +92,7 @@ public class ReceiptService {
             receiptLikeRepository.delete(receiptLike);
         }
 
-        return new ReceiptLikeRes();
+        return new ReceiptLikeRes(receiptLikeRepository.countByReceipt(receipt));
     }
 
     /**

--- a/src/main/java/example/com/moneymergebe/domain/user/controller/UserController.java
+++ b/src/main/java/example/com/moneymergebe/domain/user/controller/UserController.java
@@ -12,6 +12,7 @@ import example.com.moneymergebe.domain.user.dto.response.UserLogoutRes;
 import example.com.moneymergebe.domain.user.dto.response.UserNameRes;
 import example.com.moneymergebe.domain.user.dto.response.UserPointRes;
 import example.com.moneymergebe.domain.user.dto.response.UserProfileRes;
+import example.com.moneymergebe.domain.user.dto.response.UserSearchListRes;
 import example.com.moneymergebe.domain.user.service.UserService;
 import example.com.moneymergebe.global.jwt.JwtUtil;
 import example.com.moneymergebe.global.redis.RedisUtil;
@@ -32,6 +33,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.multipart.MultipartFile;
@@ -146,6 +148,18 @@ public class UserController {
     @GetMapping("/character")
     public CommonResponse<UserCharacterRes> getUserCharacter(@AuthenticationPrincipal UserDetailsImpl userDetails) {
         return CommonResponse.success(userService.getUserCharacter(userDetails.getUser().getUserId()));
+    }
+
+    /**
+     * 초대를 위한 사용자 조회
+     * @param userDetails 조회하는 사용자 정보
+     * @return (조회하는 사용자 제외) 입력하는 문자열과 일치하는 이메일을 가진 사용자
+     */
+    @ResponseBody
+    @GetMapping("/search")
+    public CommonResponse<UserSearchListRes> searchUser(@AuthenticationPrincipal UserDetailsImpl userDetails,
+        @RequestParam String email) {
+        return CommonResponse.success(userService.searchUser(userDetails.getUser().getUserId(), email));
     }
 
     /**

--- a/src/main/java/example/com/moneymergebe/domain/user/dto/response/UserSearchListRes.java
+++ b/src/main/java/example/com/moneymergebe/domain/user/dto/response/UserSearchListRes.java
@@ -1,0 +1,13 @@
+package example.com.moneymergebe.domain.user.dto.response;
+
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class UserSearchListRes {
+    private List<UserSearchRes> userSearchList;
+
+    public UserSearchListRes(List<UserSearchRes> userSearchList) {
+        this.userSearchList = userSearchList;
+    }
+}

--- a/src/main/java/example/com/moneymergebe/domain/user/dto/response/UserSearchRes.java
+++ b/src/main/java/example/com/moneymergebe/domain/user/dto/response/UserSearchRes.java
@@ -1,0 +1,19 @@
+package example.com.moneymergebe.domain.user.dto.response;
+
+import example.com.moneymergebe.domain.user.entity.User;
+import lombok.Getter;
+
+@Getter
+public class UserSearchRes {
+    private Long userId;
+    private String email;
+    private String profileUrl;
+    private String username;
+
+    public UserSearchRes(User user) {
+        this.userId = user.getUserId();
+        this.email = user.getEmail();
+        this.profileUrl = user.getProfileUrl();
+        this.username = user.getUsername();
+    }
+}

--- a/src/main/java/example/com/moneymergebe/domain/user/repository/UserRepository.java
+++ b/src/main/java/example/com/moneymergebe/domain/user/repository/UserRepository.java
@@ -8,5 +8,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     User findByUserId(Long userId);
     User findByUsername(String username);
     User findByEmail(String email);
+    List<User> findAllByEmailContains(String email);
 //    List<User> findAllByClusterId(Integer clusterId);
 }

--- a/src/main/java/example/com/moneymergebe/domain/user/service/UserService.java
+++ b/src/main/java/example/com/moneymergebe/domain/user/service/UserService.java
@@ -17,6 +17,8 @@ import example.com.moneymergebe.domain.user.dto.response.UserInfoRes;
 import example.com.moneymergebe.domain.user.dto.response.UserNameRes;
 import example.com.moneymergebe.domain.user.dto.response.UserPointRes;
 import example.com.moneymergebe.domain.user.dto.response.UserProfileRes;
+import example.com.moneymergebe.domain.user.dto.response.UserSearchListRes;
+import example.com.moneymergebe.domain.user.dto.response.UserSearchRes;
 import example.com.moneymergebe.domain.user.entity.User;
 import example.com.moneymergebe.domain.user.repository.UserRepository;
 import example.com.moneymergebe.global.exception.GlobalException;
@@ -150,6 +152,16 @@ public class UserService {
         User user = findUser(userId);
         Character character = findCharacter(user.getCharacterId());
         return new UserCharacterRes(character);
+    }
+
+    /**
+     * 초대를 위한 사용자 조회
+     */
+    @Transactional(readOnly = true)
+    public UserSearchListRes searchUser(Long userId, String email) {
+        List<User> userList = userRepository.findAllByEmailContains(email);
+        List<UserSearchRes> resList = userList.stream().filter(user -> !user.getUserId().equals(userId)).map(UserSearchRes::new).toList();
+        return new UserSearchListRes(resList);
     }
 
     /**


### PR DESCRIPTION
## 개요
이메일로 사용자 조회 api 추가

## 작업사항
- 이메일로 사용자 조회 api 추가
- 가계부 등록 시 사용자 색상도 설정하도록 추가
- 받은 영수증 좋아요 시 좋아요 개수 반환하도록 수정

## 관련 이슈
- 
